### PR TITLE
Slimit fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ beautifulsoup4>=4.3.2
 chardet>=2.2.1
 html5lib>=0.999
 requests>=2.3.5
-slimit>=0.8.1
+git@https://github.com/rspivak/slimit.git@40956e7fc6e954b3e6d7b629faeb3303f5efb7ea#egg=slimit
 tinycss2>=0.4
-ply==3.4
+ply==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ beautifulsoup4>=4.3.2
 chardet>=2.2.1
 html5lib>=0.999
 requests>=2.3.5
-git@https://github.com/rspivak/slimit.git@40956e7fc6e954b3e6d7b629faeb3303f5efb7ea#egg=slimit
+git+https://github.com/rspivak/slimit.git@40956e7fc6e954b3e6d7b629faeb3303f5efb7ea#egg=slimit
 tinycss2>=0.4
 ply==3.11

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,17 @@ else:
         docstring = fh.read()
     packages = [b'html5print']           # without this setup will crash
 
-with open('requirements.txt') as fh:
-    requires = fh.read().splitlines()
-
+#with open('requirements.txt') as fh:
+#    requires = fh.read().splitlines()
+requires = [
+    'beautifulsoup4>=4.3.2',
+    'chardet>=2.2.1',
+    'html5lib>=0.999',
+    'requests>=2.3.5',
+    'slimit @git@https://github.com/rspivak/slimit.git@40956e7fc6e954b3e6d7b629faeb3303f5efb7ea',
+    'tinycss2>=0.4',
+    'ply==3.11'
+]
 
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ requires = [
     'chardet>=2.2.1',
     'html5lib>=0.999',
     'requests>=2.3.5',
-    'slimit @git@https://github.com/rspivak/slimit.git@40956e7fc6e954b3e6d7b629faeb3303f5efb7ea',
+    'slimit @git+https://github.com/rspivak/slimit.git@40956e7fc6e954b3e6d7b629faeb3303f5efb7ea',
     'tinycss2>=0.4',
     'ply==3.11'
 ]


### PR DESCRIPTION
On Recent local builds of netsuite_api_client Andy and I ran into an issue with html5print library using a number version of slimit that is a python2 library. The author has a commit that has python3 syntax fixes for the library and this update pulls that commit in instead of the previous numbered library.

Bones said that he did not encounter this in his setup. I checked the server it's running 3.7.9. Testing locally with that version it fails on the same import statement, but checking the library itself on the server it has had modifications to make it compatible with python3.  Not sure if there is a build setup that got lost or how that's accounted for when we deploy the netsuite_api_client.